### PR TITLE
Enable missing config to generate dagger factories in whetstone-worker

### DIFF
--- a/whetstone-worker/build.gradle.kts
+++ b/whetstone-worker/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
     id("com.squareup.anvil")
 }
 
+anvil {
+    generateDaggerFactories.set(true)
+}
+
 dependencies {
     implementation(projects.whetstone)
     implementation(libs.dagger)


### PR DESCRIPTION
Closes #53 