### PR TITLE
Add Maven Central's latest version badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.deliveryhero.whetstone/whetstone/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.deliveryhero.whetstone/whetstone)
+
 # Whetstone
 
 > "An Anvil forges a Dagger. A Whetstone sharpens it. And when you're not planning on using your Dagger, you may keep it in something that rhymes with kilt." — [Tiago Cunha](https://github.com/laggedHero).


### PR DESCRIPTION
Fixes https://github.com/deliveryhero/whetstone/issues/64

I'm using the badge from [here](https://github.com/softwaremill/maven-badges). We need to point to a specific artifact, so based on the options [here](https://search.maven.org/search?q=com.deliveryhero.whetstone), I thought it'd make sense to go with the simple `whetstone`, but let me know if we should point to a different one.