### PR TITLE
Add an activity level context binding

### DIFF
--- a/whetstone/src/main/java/com/deliveryhero/whetstone/activity/ActivityModule.kt
+++ b/whetstone/src/main/java/com/deliveryhero/whetstone/activity/ActivityModule.kt
@@ -1,13 +1,21 @@
 package com.deliveryhero.whetstone.activity
 
+import android.app.Activity
+import android.content.Context
+import com.deliveryhero.whetstone.ForScope
 import com.deliveryhero.whetstone.injector.MembersInjectorMap
 import com.squareup.anvil.annotations.ContributesTo
+import dagger.Binds
 import dagger.Module
 import dagger.multibindings.Multibinds
 
 @Module
 @ContributesTo(ActivityScope::class)
 public interface ActivityModule {
+
+    @Binds
+    @ForScope(ActivityScope::class)
+    public fun Activity.bindContext(): Context
 
     @Multibinds
     public fun membersInjectors(): MembersInjectorMap


### PR DESCRIPTION
It is currently only possible to inject an Application context into dependencies but there are many places where an Activity context is also useful, such as an abstraction that handles Chrome Custom Tabs, where a call to `startActivity` will throw unless it is an Activity context.
