### PR TITLE
Remove unused appcompat dependency

### DIFF
--- a/whetstone/build.gradle.kts
+++ b/whetstone/build.gradle.kts
@@ -18,7 +18,6 @@ dependencies {
     implementation(libs.androidxLifecycleSavedState)
 
     implementation(libs.androidxCore)
-    implementation(libs.androidxAppCompat)
     implementation(libs.androidxActivity)
     api(libs.androidxFragment)
 


### PR DESCRIPTION
It appears this dependency was not being used.

Modern compose apps mostly do not need appcompat anymore, so Whetstone is an unnecessary source of this dependency at the moment. This PR fixes that.