### PR TITLE
Make fromApplication call non-blocking the UI thread

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradle = "8.1.0"
+androidGradle = "8.2.2"
 androidxActivity = "1.5.0"
 androidxAppCompat = "1.3.1"
 androidxCompose = "1.6.1"

--- a/whetstone-worker/src/main/java/com/deliveryhero/whetstone/worker/WhetstoneWorkerInitializer.kt
+++ b/whetstone-worker/src/main/java/com/deliveryhero/whetstone/worker/WhetstoneWorkerInitializer.kt
@@ -6,6 +6,8 @@ import androidx.startup.Initializer
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import com.deliveryhero.whetstone.Whetstone
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 
 public class WhetstoneWorkerInitializer : Initializer<WorkManager> {
 
@@ -21,9 +23,11 @@ public class WhetstoneWorkerInitializer : Initializer<WorkManager> {
 
 
 private fun Whetstone.installWorkerFactory(application: Application) {
-    val parentComponent = fromApplication<WorkerComponent.ParentComponent>(application)
-    val configuration = Configuration.Builder()
-        .setWorkerFactory(parentComponent.getWorkerFactory())
-        .build()
+    val configuration = runBlocking(Dispatchers.IO) {
+        val parentComponent = fromApplication<WorkerComponent.ParentComponent>(application)
+        return@runBlocking Configuration.Builder()
+            .setWorkerFactory(parentComponent.getWorkerFactory())
+            .build()
+    }
     WorkManager.initialize(application, configuration)
 }


### PR DESCRIPTION
Offload call to the `fromApplication` method to IO dispatcher, so that it doesn't block UI thread when creating AppComponent. 
This should help to avoid possible ANRs on low-end devices, when the component creation might also clash with GC and cause a delay.