### PR TITLE
Revert the https://github.com/deliveryhero/whetstone/pull/94

### DIFF
--- a/whetstone-worker/src/main/java/com/deliveryhero/whetstone/worker/WhetstoneWorkerInitializer.kt
+++ b/whetstone-worker/src/main/java/com/deliveryhero/whetstone/worker/WhetstoneWorkerInitializer.kt
@@ -6,8 +6,6 @@ import androidx.startup.Initializer
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import com.deliveryhero.whetstone.Whetstone
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 
 public class WhetstoneWorkerInitializer : Initializer<WorkManager> {
 
@@ -23,11 +21,9 @@ public class WhetstoneWorkerInitializer : Initializer<WorkManager> {
 
 
 private fun Whetstone.installWorkerFactory(application: Application) {
-    val configuration = runBlocking(Dispatchers.IO) {
-        val parentComponent = fromApplication<WorkerComponent.ParentComponent>(application)
-        return@runBlocking Configuration.Builder()
-            .setWorkerFactory(parentComponent.getWorkerFactory())
-            .build()
-    }
+    val parentComponent = fromApplication<WorkerComponent.ParentComponent>(application)
+    val configuration = Configuration.Builder()
+        .setWorkerFactory(parentComponent.getWorkerFactory())
+        .build()
     WorkManager.initialize(application, configuration)
 }


### PR DESCRIPTION
Revert the https://github.com/deliveryhero/whetstone/pull/94, because it's still blocking, and doesn't help with ANRs