### PR TITLE
[REL-877] Use LazyClassKey

### DIFF
--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/handlers/BindingsModuleHandler.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/handlers/BindingsModuleHandler.kt
@@ -15,6 +15,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.multibindings.ClassKey
 import dagger.multibindings.IntoMap
+import dagger.multibindings.LazyClassKey
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.name.FqName
 
@@ -74,7 +75,7 @@ internal class BindingsModuleHandler : CodegenHandler {
             .addMember("%T::class", componentScopeCn)
             .build()
 
-        val classKeyAnnotation = AnnotationSpec.builder(ClassKey::class)
+        val classKeyAnnotation = AnnotationSpec.builder(LazyClassKey::class)
             .addMember("%T::class", className)
             .build()
 

--- a/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/TestUtil.kt
+++ b/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/TestUtil.kt
@@ -12,13 +12,12 @@ import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import com.tschuchort.compiletesting.JvmCompilationResult
-import com.tschuchort.compiletesting.KotlinCompilation
 import dagger.Binds
 import dagger.Component
 import dagger.MembersInjector
 import dagger.Module
-import dagger.multibindings.ClassKey
 import dagger.multibindings.IntoMap
+import dagger.multibindings.LazyClassKey
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import javax.inject.Singleton
 import kotlin.reflect.KClass
@@ -40,7 +39,7 @@ internal fun JvmCompilationResult.validateInstanceBinding(
     val bindsMethod = bindingModule.declaredMemberFunctions.single { it.name == "binds" }
     assertTrue(bindsMethod.hasAnnotation<Binds>())
     assertTrue(bindsMethod.hasAnnotation<IntoMap>())
-    assertEquals(clas, bindsMethod.findAnnotation<ClassKey>()?.value)
+    assertEquals(clas, bindsMethod.findAnnotation<LazyClassKey>()?.value)
     assertEquals(clas, bindsMethod.findParameterByName("target")?.type?.classifier)
     assertEquals(baseClass, bindsMethod.returnType.classifier)
 }
@@ -56,7 +55,7 @@ internal fun JvmCompilationResult.validateInjectorBinding(classUnderTest: String
     val bindsMethod = bindingModule.declaredMemberFunctions.single { it.name == "binds" }
     assertTrue(bindsMethod.hasAnnotation<Binds>())
     assertTrue(bindsMethod.hasAnnotation<IntoMap>())
-    assertEquals(clas, bindsMethod.findAnnotation<ClassKey>()?.value)
+    assertEquals(clas, bindsMethod.findAnnotation<LazyClassKey>()?.value)
     assertEquals(
         membersInjector.parameterizedBy(clas.asClassName()),
         bindsMethod.findParameterByName("target")?.type?.asTypeName()


### PR DESCRIPTION
This PR aims to take advantage of @LazyClassKey in dagger that supports using class names as a map key. Unlike the existing @ClassKey, the map generated by @LazyClassKey won’t eagerly load all of the classes for the keys. This can be useful in situations or environments where class loading can be expensive, such as on Android. For more information, see https://dagger.dev/dev-guide/multibindings 