### PR TITLE
Manually generate XBindingModule_Binds_LazyMapKey

### DIFF
--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/CodegenHandler.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/CodegenHandler.kt
@@ -10,6 +10,6 @@ internal interface CodegenHandler {
     fun processClass(clas: ClassReference, module: ModuleDescriptor): GeneratedFileInfo?
 }
 
-internal fun defaultCodegenHandlers(): List<CodegenHandler> {
-    return listOf(BindingsModuleHandler(), AppComponentHandler())
+internal fun defaultCodegenHandlers(generateFactories: Boolean): List<CodegenHandler> {
+    return listOf(BindingsModuleHandler(generateFactories), AppComponentHandler())
 }

--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/FqNames.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/FqNames.kt
@@ -11,4 +11,7 @@ internal object FqNames {
     @JvmField val AUTO_INSTANCE = FqName("com.deliveryhero.whetstone.meta.AutoInstanceBinding")
     @JvmField val SINGLE_IN = FqName("com.deliveryhero.whetstone.SingleIn")
     @JvmField val APPLICATION = FqName("android.app.Application")
+    @JvmField val JVM_FIELD = FqName("kotlin.jvm.JvmField")
+    @JvmField val KEEP_FIELD_TYPE = FqName("dagger.internal.KeepFieldType")
+    @JvmField val ID_NAME_STRING = FqName("dagger.internal.IdentifierNameString")
 }

--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/WhetstoneCodeGenerator.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/WhetstoneCodeGenerator.kt
@@ -9,13 +9,18 @@ import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferenc
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
+import kotlin.LazyThreadSafetyMode.NONE
 
 @AutoService(CodeGenerator::class)
 public class WhetstoneCodeGenerator : CodeGenerator {
 
-    private val codegenHandlers = defaultCodegenHandlers()
+    private var isAnvilGeneratingDaggerFactories = false
+    private val codegenHandlers by lazy(NONE) { defaultCodegenHandlers(isAnvilGeneratingDaggerFactories) }
 
-    override fun isApplicable(context: AnvilContext): Boolean = true
+    override fun isApplicable(context: AnvilContext): Boolean {
+        isAnvilGeneratingDaggerFactories = context.generateFactories
+        return true
+    }
 
     override fun generateCode(
         codeGenDir: File,

--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/handlers/BindingsModuleHandler.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/handlers/BindingsModuleHandler.kt
@@ -19,7 +19,7 @@ import dagger.multibindings.LazyClassKey
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.name.FqName
 
-internal class BindingsModuleHandler : CodegenHandler {
+internal class BindingsModuleHandler(private val generateFactories: Boolean) : CodegenHandler {
 
     private val dynamicProviderMap = hashMapOf<FqName, ModuleInfoProvider?>().apply {
         val injectorModule = ExplicitInjectorModuleInfoProvider()
@@ -100,7 +100,7 @@ internal class BindingsModuleHandler : CodegenHandler {
                 .build()
 
             addType(moduleInterfaceSpec)
-            if (provider is InstanceModuleInfoProvider) {
+            if (provider is InstanceModuleInfoProvider && generateFactories) {
                 // Whetstone is explicitly generating this extra type to properly support
                 // Dagger's LazyClassKey. Ideally, this should be handled by Anvil, but that
                 // isn't happening now, so until then, we'll maintain this workaround

--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/handlers/BindingsModuleHandler.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/handlers/BindingsModuleHandler.kt
@@ -5,6 +5,7 @@ import com.deliveryhero.whetstone.compiler.FqNames
 import com.deliveryhero.whetstone.compiler.GeneratedFileInfo
 import com.deliveryhero.whetstone.compiler.getValue
 import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference
@@ -13,7 +14,6 @@ import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.kotlinpoet.*
 import dagger.Binds
 import dagger.Module
-import dagger.multibindings.ClassKey
 import dagger.multibindings.IntoMap
 import dagger.multibindings.LazyClassKey
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
@@ -28,7 +28,7 @@ internal class BindingsModuleHandler : CodegenHandler {
 
     override fun processClass(clas: ClassReference, module: ModuleDescriptor): GeneratedFileInfo? {
         val provider = findProvider(clas) ?: return null
-        return generateModule(provider, clas)
+        return generateModule(provider, clas, module)
     }
 
     private fun findProvider(clas: ClassReference): ModuleInfoProvider? {
@@ -61,7 +61,7 @@ internal class BindingsModuleHandler : CodegenHandler {
         return result
     }
 
-    private fun generateModule(provider: ModuleInfoProvider, clas: ClassReference): GeneratedFileInfo {
+    private fun generateModule(provider: ModuleInfoProvider, clas: ClassReference, module: ModuleDescriptor): GeneratedFileInfo {
         val className = clas.asClassName()
         val packageName = clas.packageFqName.safePackageString(
             dotPrefix = false,
@@ -100,9 +100,32 @@ internal class BindingsModuleHandler : CodegenHandler {
                 .build()
 
             addType(moduleInterfaceSpec)
+            if (provider is InstanceModuleInfoProvider) {
+                // Whetstone is explicitly generating this extra type to properly support
+                // Dagger's LazyClassKey. Ideally, this should be handled by Anvil, but that
+                // isn't happening now, so until then, we'll maintain this workaround
+                addType(generateLazyMapKey(outputFileName, className, module))
+            }
         }
 
         return GeneratedFileInfo(packageName, outputFileName, content, clas.containingFileAsJavaFile)
+    }
+
+    private fun generateLazyMapKey(outputFileName: String, className: ClassName, module: ModuleDescriptor): TypeSpec {
+        val keepFieldType = PropertySpec.builder("keepFieldType", className.copy(nullable = true))
+            .addAnnotation(FqNames.JVM_FIELD.asClassName(module))
+            .addAnnotation(FqNames.KEEP_FIELD_TYPE.asClassName(module))
+            .initializer("null")
+            .build()
+        val lazyClassKeyName = PropertySpec.builder("lazyClassKeyName", STRING)
+            .addModifiers(KModifier.CONST)
+            .initializer("%S", className.canonicalName)
+            .build()
+        return TypeSpec.objectBuilder("${outputFileName}_Binds_LazyMapKey")
+            .addAnnotation(FqNames.ID_NAME_STRING.asClassName(module))
+            .addProperty(keepFieldType)
+            .addProperty(lazyClassKeyName)
+            .build()
     }
 
     private fun <K, V> MutableMap<K, V?>.getOrPutNullable(key: K, func: () -> V?): V? {

--- a/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/CodegenTest.kt
+++ b/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/CodegenTest.kt
@@ -25,6 +25,7 @@ internal class CodegenTest {
             """.trimIndent()
         ) {
             validateInstanceBinding("MyFragment", Fragment::class, FragmentScope::class)
+            validateLazyBindingKey("MyFragment")
         }
     }
 
@@ -40,6 +41,7 @@ internal class CodegenTest {
             """.trimIndent()
         ) {
             validateInstanceBinding("MyViewModel", ViewModel::class, ViewModelScope::class)
+            validateLazyBindingKey("MyViewModel")
         }
     }
 

--- a/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/CodegenTest.kt
+++ b/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/CodegenTest.kt
@@ -22,7 +22,8 @@ internal class CodegenTest {
 
                 @ContributesFragment
                 class MyFragment : Fragment()
-            """.trimIndent()
+            """.trimIndent(),
+            generateDaggerFactories = true
         ) {
             validateInstanceBinding("MyFragment", Fragment::class, FragmentScope::class)
             validateLazyBindingKey("MyFragment")
@@ -38,7 +39,8 @@ internal class CodegenTest {
 
                 @ContributesViewModel
                 class MyViewModel : ViewModel()
-            """.trimIndent()
+            """.trimIndent(),
+            generateDaggerFactories = true
         ) {
             validateInstanceBinding("MyViewModel", ViewModel::class, ViewModelScope::class)
             validateLazyBindingKey("MyViewModel")


### PR DESCRIPTION
Manually generate `XBindingModule_Binds_LazyMapKey` type to properly support `LazyClassKey`

This shouldn't be needed in future once this support lands directly in Anvil. But for now, this is a workaround to ensure that Dagger's new `LazyClassKey` works correctly in Whetstone

Related Anvil issue: https://github.com/square/anvil/issues/1079