### PR TITLE
Follow up: minor improvement from _LazyMapKey type generation

### DIFF
--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/CodegenHandler.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/CodegenHandler.kt
@@ -1,15 +1,9 @@
 package com.deliveryhero.whetstone.compiler
 
-import com.deliveryhero.whetstone.compiler.handlers.AppComponentHandler
-import com.deliveryhero.whetstone.compiler.handlers.BindingsModuleHandler
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 
 internal interface CodegenHandler {
 
     fun processClass(clas: ClassReference, module: ModuleDescriptor): GeneratedFileInfo?
-}
-
-internal fun defaultCodegenHandlers(generateFactories: Boolean): List<CodegenHandler> {
-    return listOf(BindingsModuleHandler(generateFactories), AppComponentHandler())
 }

--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/FqNames.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/FqNames.kt
@@ -11,7 +11,4 @@ internal object FqNames {
     @JvmField val AUTO_INSTANCE = FqName("com.deliveryhero.whetstone.meta.AutoInstanceBinding")
     @JvmField val SINGLE_IN = FqName("com.deliveryhero.whetstone.SingleIn")
     @JvmField val APPLICATION = FqName("android.app.Application")
-    @JvmField val JVM_FIELD = FqName("kotlin.jvm.JvmField")
-    @JvmField val KEEP_FIELD_TYPE = FqName("dagger.internal.KeepFieldType")
-    @JvmField val ID_NAME_STRING = FqName("dagger.internal.IdentifierNameString")
 }

--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/WhetstoneCodeGenerator.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/WhetstoneCodeGenerator.kt
@@ -1,5 +1,7 @@
 package com.deliveryhero.whetstone.compiler
 
+import com.deliveryhero.whetstone.compiler.handlers.AppComponentHandler
+import com.deliveryhero.whetstone.compiler.handlers.BindingsModuleHandler
 import com.google.auto.service.AutoService
 import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.CodeGenerator
@@ -9,16 +11,16 @@ import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferenc
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
-import kotlin.LazyThreadSafetyMode.NONE
 
 @AutoService(CodeGenerator::class)
 public class WhetstoneCodeGenerator : CodeGenerator {
 
-    private var isAnvilGeneratingDaggerFactories = false
-    private val codegenHandlers by lazy(NONE) { defaultCodegenHandlers(isAnvilGeneratingDaggerFactories) }
+    private val codegenHandlers = mutableListOf<CodegenHandler>()
 
     override fun isApplicable(context: AnvilContext): Boolean {
-        isAnvilGeneratingDaggerFactories = context.generateFactories
+        require(codegenHandlers.isEmpty())
+        codegenHandlers += BindingsModuleHandler(context.generateFactories)
+        codegenHandlers += AppComponentHandler()
         return true
     }
 


### PR DESCRIPTION
This is a minor follow-up improvement for #106

Reference annotation types directly and initialize codegen handlers in `CodeGenerator#isApplicable`

Since we already include Dagger runtime in the compiler, we can simply reference its annotations as well as Kotlin's `JvmField` directly without loading them manually.
Also, we know that `CodeGenerator#isApplicable` is called once, so we can simplify the init logic by doing the initialization work for `WhetstoneCodeGenerator#codegenHandlers` directly there