### PR TITLE
Fix: Generate _LazyMapKey for all bindings

### DIFF
--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/handlers/BindingsModuleHandler.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/handlers/BindingsModuleHandler.kt
@@ -101,7 +101,7 @@ internal class BindingsModuleHandler(private val generateFactories: Boolean) : C
                 .build()
 
             addType(moduleInterfaceSpec)
-            if (provider is InstanceModuleInfoProvider && generateFactories) {
+            if (generateFactories) {
                 // Whetstone is explicitly generating this extra type to properly support
                 // Dagger's LazyClassKey. Ideally, this should be handled by Anvil, but that
                 // isn't happening now, so until then, we'll maintain this workaround

--- a/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/CodegenTest.kt
+++ b/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/CodegenTest.kt
@@ -57,9 +57,11 @@ internal class CodegenTest {
 
                 @ContributesInjector(ActivityScope::class)
                 class MyActivity: Activity()
-            """.trimIndent()
+            """.trimIndent(),
+            generateDaggerFactories = true
         ) {
             validateInjectorBinding("MyActivity", ActivityScope::class)
+            validateLazyBindingKey("MyActivity")
         }
     }
 
@@ -72,9 +74,11 @@ internal class CodegenTest {
 
                 @ContributesActivityInjector
                 class MyActivity: Activity()
-            """.trimIndent()
+            """.trimIndent(),
+            generateDaggerFactories = true
         ) {
             validateInjectorBinding("MyActivity", ActivityScope::class)
+            validateLazyBindingKey("MyActivity")
         }
     }
 
@@ -88,8 +92,10 @@ internal class CodegenTest {
                 @ContributesAppInjector(generateAppComponent = false)
                 class MyApplication: Application()
             """.trimIndent(),
+            generateDaggerFactories = true
         ) {
             validateInjectorBinding("MyApplication", ApplicationScope::class)
+            validateLazyBindingKey("MyApplication")
             // generating app component requires kapt which seems broken in the tests
             // validateAppComponent()
         }


### PR DESCRIPTION
We originally generated the _LazyMapKey only for the instance bindings. But that needs to actually be generated for injector bindings as well.

This PR fixes that