### PR TITLE
Cover case without _LazyMapKey class gen with test

### DIFF
--- a/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/CodegenTest.kt
+++ b/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/CodegenTest.kt
@@ -48,6 +48,23 @@ internal class CodegenTest {
     }
 
     @Test
+    fun contributesViewModel_noLazyBinding() {
+        compileAnvil(
+            """
+                import com.deliveryhero.whetstone.viewmodel.ContributesViewModel
+                import androidx.lifecycle.ViewModel
+
+                @ContributesViewModel
+                class MyViewModel : ViewModel()
+            """.trimIndent(),
+            generateDaggerFactories = false
+        ) {
+            validateInstanceBinding("MyViewModel", ViewModel::class, ViewModelScope::class)
+            validateNoLazyBindingKey("MyViewModel")
+        }
+    }
+
+    @Test
     fun contributesInjector() {
         compileAnvil(
             """

--- a/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/TestUtil.kt
+++ b/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/TestUtil.kt
@@ -24,6 +24,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.*
 import kotlin.reflect.typeOf
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 internal fun JvmCompilationResult.validateInstanceBinding(
@@ -57,6 +58,11 @@ internal fun JvmCompilationResult.validateLazyBindingKey(classUnderTest: String)
     assertTrue(lazyClassKeyName.isConst)
     assertEquals(typeOf<String>(), lazyClassKeyName.returnType)
     assertEquals(clas.qualifiedName, lazyClassKeyName.call())
+}
+
+internal fun JvmCompilationResult.validateNoLazyBindingKey(classUnderTest: String) {
+    val className = "${classUnderTest}BindingsModule_Binds_LazyMapKey"
+    assertFailsWith<ClassNotFoundException> { classLoader.loadClass(className).kotlin }
 }
 
 internal fun JvmCompilationResult.validateInjectorBinding(classUnderTest: String, scope: KClass<*>) {


### PR DESCRIPTION
Add test for case where we shouldn't generate the extra _LazyMapKey class. This is typically when the generation is already delegated to Dagger