### PR TITLE
[REL -1040]  Update CI to Publish Whetstone to Maven on Release Events

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,31 +4,38 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [created, published]
 
 jobs:
   publish-release:
-
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: Set JDK version
         uses: actions/setup-java@v2
         with:
           distribution: zulu
           java-version: 17
+
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+
       - name: Publish artifact
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername : ${{ secrets.SONATYPE_NEXUS_ACTOR_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword : ${{ secrets.SONATYPE_NEXUS_ACTOR_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_ACTOR_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_ACTOR_PASSWORD }}
+          ORG_GRADLE_PROJECT_signing.keyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signing.password: ${{ secrets.SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signing.key: ${{ secrets.SIGNING_KEY }}
 
           # The GITHUB_REF tag comes in the format 'refs/tags/xxx'.
           # If we split on '/' and take the 3rd value,
           # we can get the release name.
         run: |
-          echo "New version: $(grep "VERSION_NAME" gradle.properties | cut -d'=' -f2)"
-          echo "Github username: ${GITHUB_ACTOR}"
-          ./gradlew clean -x test -x lint publish :whetstone-gradle-plugin:publish
+            echo "New version: $(grep "VERSION_NAME" gradle.properties | cut -d'=' -f2)"
+            echo "Github username: ${GITHUB_ACTOR}"
+            ./gradlew clean -x test -x lint publish :whetstone-gradle-plugin:publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,13 +7,26 @@ plugins {
     alias(libs.plugins.anvil).apply(false)
     alias(libs.plugins.mavenPublish).apply(false)
     alias(libs.plugins.binaryValidator)
+    `maven-publish`
+    signing
 }
+
+signing {
+    useInMemoryPgpKeys(
+        project.findProperty("signing.keyId") as String?,
+        project.findProperty("signing.key") as String?,
+        project.findProperty("signing.password") as String?
+    )
+    sign(publishing.publications)
+}
+
 
 apiValidation {
     ignoredProjects.addAll(listOf("sample", "whetstone-compiler"))
 }
 
-tasks.register<Delete>("clean") {
+
+tasks.named<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }
 


### PR DESCRIPTION
:clipboard: Jira Link
-
https://deliveryhero.atlassian.net/browse/REL-1040

:arrows_counterclockwise: Type of change:
-
Maintenance

:dart: What's the purpose of this PR?
- 
The purpose of this pull request is to enhance the release automation process for the Whetstone by:

- Triggering artifact publishing on GitHub release events, not just on main branch pushes.
- Ensuring that signed artifacts are correctly published to Maven Central when a new release is created.
- Adding GPG signing keys securely through GitHub Actions secrets.

:memo: What is the impact of this change?
- 
- Automates artifact publishing on GitHub release creation
- Ensures artifacts are GPG-signed and deployed to Maven Central
- Reduces manual release steps and human error