### PR TITLE
[REL -1285] Update CI Workflow to Disable Shallow Cloning (Fix "Commit doesn't exist" Error) in Whetstone

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -95,6 +95,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
:clipboard: Jira Link
-
https://deliveryhero.atlassian.net/browse/REL-1285

:arrows_counterclockwise: Type of change:
-
Maintenance

:dart: What's the purpose of this PR?
- 
To make our CI pipeline more resilient to common git operations like rebasing, resetting, and force-pushing—especially during collaborative pull request workflows. Currently, shallow cloning (fetch-depth: 1) causes CI jobs to fail when a force-push updates a commit that is no longer reachable from the default history fetched by the runner.

This PR will disable shallow cloning by setting fetch-depth: 0 in the actions/checkout step, allowing the CI runner to access the full git history and reliably locate any commit referenced in PRs.

:memo: What is the impact of this change?
- 
- Prevents CI failures due to "Commit doesn't exist" errors after a force-push
- Improves reliability for contributors who rebase or squash commits during PRs
- Ensures tools like danger can access the full history they need