### PR TITLE
Align code generation with dagger practices

### DIFF
--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/WhetstoneCodeGenerator.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/WhetstoneCodeGenerator.kt
@@ -66,8 +66,8 @@ private fun writeProguardFileContent(
     fileName: String,
     content: String,
 ): File {
-    val directory = File(codeGenDir, packageName)
-    val file = File(directory, "$fileName.txt")
+    val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))
+    val file = File(directory, "$fileName.pro")
     check(file.parentFile.exists() || file.parentFile.mkdirs()) {
         "Could not generate package directory: ${file.parentFile}"
     }

--- a/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/handlers/BindingsModuleHandler.kt
+++ b/whetstone-compiler/src/main/java/com/deliveryhero/whetstone/compiler/handlers/BindingsModuleHandler.kt
@@ -28,9 +28,6 @@ import dagger.multibindings.LazyClassKey
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.name.FqName
 
-// Dagger uses "-keep,allowobfuscation,allowshrinking class "; https://github.com/google/dagger/blob/master/dagger-compiler/main/java/dagger/internal/codegen/processingstep/LazyClassKeyProcessingStep.java
-// When we use the same configuration, application still crash when we use a value from the map injection.
-// That is why we are using slightly different version. keepnames is short of keep,allowobfuscation and it works fine in this case.
 private const val PROGUARD_KEEP_RULE = "-keep,allowobfuscation,allowshrinking class"
 
 internal class BindingsModuleHandler(private val generateFactories: Boolean) : CodegenHandler {

--- a/whetstone-gradle-plugin/src/main/kotlin/com/deliveryhero/whetstone/gradle/WhetstonePlugin.kt
+++ b/whetstone-gradle-plugin/src/main/kotlin/com/deliveryhero/whetstone/gradle/WhetstonePlugin.kt
@@ -78,7 +78,7 @@ public class WhetstonePlugin : Plugin<Project> {
                     }
 
                 target.tasks.withType<ExportConsumerProguardFilesTask>().configureEach {
-                    if (name.contains( variantName, true)) {
+                    if (name.contains(variantName, true)) {
                         consumerProguardFiles.from(generatedProguardFiles)
                     }
                 }

--- a/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/TestUtil.kt
+++ b/whetstone/src/test/java/com/deliveryhero/whetstone/codegen/TestUtil.kt
@@ -26,7 +26,9 @@ import kotlin.reflect.full.*
 import kotlin.reflect.typeOf
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.text.replace
 
 internal fun JvmCompilationResult.validateInstanceBinding(
     classUnderTest: String,
@@ -56,14 +58,14 @@ internal fun JvmCompilationResult.validateLazyBindingKey(classUnderTest: String)
     assertEquals(clas, keepFieldType.returnType.classifier)
 
     val lazyClassKeyName = generatedClass.declaredMemberProperties.single { it.name == "lazyClassKeyName" }
-    assertTrue(lazyClassKeyName.isConst)
+    assertFalse(lazyClassKeyName.isConst)
     assertEquals(typeOf<String>(), lazyClassKeyName.returnType)
     assertEquals(clas.qualifiedName, lazyClassKeyName.call())
 
-    val simpleName = classUnderTest.substringAfterLast('.')
-    val proguardFileName = "${simpleName}BindingsModule_Binds_LazyMapKey"
-    val anvilFolder = File(outputDirectory.parentFile, "build/anvil")
-    val generatedProFile = File(anvilFolder, "META-INF/proguard/$proguardFileName.txt")
+    val simpleName = classUnderTest.replace('.', '_')
+    val proguardFileName = "${simpleName}BindingsModule_LazyClassKeys"
+    val anvilFolder = File(outputDirectory.parentFile, "build/anvil/META-INF/proguard")
+    val generatedProFile = File(anvilFolder, "$proguardFileName.pro")
     assertTrue(generatedProFile.exists())
 }
 


### PR DESCRIPTION
This commit refactors how Whetstone generates and consumes Proguard files to align with standard Android and Dagger conventions.

Key changes include:
- Generated LazyClassKey string is not const any more. R8 does have a special rule called -identifiernamestring to allow changing string literals assigned to fields, but for static final fields that does not work, as both javac and kotlinc inlines these constants. This is the reason why we had crashed even after adding same proguard rules. 
- The Proguard file extension is changed from `.txt` to `.pro`.
- Generated Proguard files are now placed in the `META-INF/proguard` directory, same as Dagger but AGP doesnt pickup those automatically. The Gradle plugin is updated to locate files in this new path.
- The keep rule for `LazyClassKey` is updated to match Dagger's (`-keep,allowobfuscation,allowshrinking class`), removing the previous `-keepnames` workaround.
- The generation logic for `LazyClassKey` and its associated Proguard file is refactored for clarity, including renaming helper functions and output files.