### PR TITLE
CI: Trigger publish workflow only on published releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,11 +1,8 @@
-name: Publish SNAPSHOT
+name: Publish
 
 on:
-  push:
-    branches:
-      - main
   release:
-    types: [created, published]
+    types: [published]
 
 jobs:
   publish-release:

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+
+# Kotlin
+.kotlin

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ Releasing
 3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
 4. Create a pre-release on GitHub Releases with a tag. This will trigger the release action. Alternatively, run `./gradlew clean publish :whetstone-gradle-plugin:publish` locally.
 5. Visit [Sonatype Nexus](https://s01.oss.sonatype.org/) and promote the artifact.
-6. Skip if you used githup releases on step 4. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
+6. Skip if you used GitHub Releases in step 4. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
 7. Update the root `gradle.properties` to the next SNAPSHOT version.
 8. `git commit -am "Prepare next development version."`
 9. `git push && git push --tags`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,9 +4,9 @@ Releasing
 1. Change the `VERSION_NAME` in root `gradle.properties` to a non-SNAPSHOT version to be released. 
 2. Run `./gradlew clean build` to make sure project builds successfully.
 3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
-4. `./gradlew clean publish :whetstone-gradle-plugin:publish`.
+4. Create a pre-release on github releases with tag. That will trigger release action. Or run `./gradlew clean publish :whetstone-gradle-plugin:publish` locally.
 5. Visit [Sonatype Nexus](https://s01.oss.sonatype.org/) and promote the artifact.
-6. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
+6. Skip if you used githup releases on step 4. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
 7. Update the root `gradle.properties` to the next SNAPSHOT version.
 8. `git commit -am "Prepare next development version."`
 9. `git push && git push --tags`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@ Releasing
 1. Change the `VERSION_NAME` in root `gradle.properties` to a non-SNAPSHOT version to be released. 
 2. Run `./gradlew clean build` to make sure project builds successfully.
 3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
-4. Create a pre-release on github releases with tag. That will trigger release action. Or run `./gradlew clean publish :whetstone-gradle-plugin:publish` locally.
+4. Create a pre-release on GitHub Releases with a tag. This will trigger the release action. Alternatively, run `./gradlew clean publish :whetstone-gradle-plugin:publish` locally.
 5. Visit [Sonatype Nexus](https://s01.oss.sonatype.org/) and promote the artifact.
 6. Skip if you used githup releases on step 4. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
 7. Update the root `gradle.properties` to the next SNAPSHOT version.


### PR DESCRIPTION
The publish workflow is updated to only trigger when a release is published, removing the previous trigger on pushes to the main branch.

Also, adds the `.kotlin` directory to `.gitignore`.