### PR TITLE
Refactor plugin to support product flavors

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,5 @@
 name: Run tests
-on: [pull_request]
+on: [ pull_request ]
 
 jobs:
   run-tests:
@@ -14,6 +14,6 @@ jobs:
           distribution: zulu
           java-version: 17
       - name: Run unit tests
-        run: ./gradlew -x sample:testDebugUnitTest whetstone-compiler:test testDebugUnitTest
+        run: ./gradlew build
       - name: Build sample app
-        run: ./gradlew sample:assembleDebug
+        run: ./gradlew sample:assembleRelease

--- a/sample-library/build.gradle.kts
+++ b/sample-library/build.gradle.kts
@@ -25,6 +25,17 @@ android {
     kotlinOptions {
         jvmTarget = "11"
     }
+
+    val dimension = "di_dimension"
+    flavorDimensions += dimension
+    productFlavors {
+        register("hilt") {
+            this.dimension = dimension
+        }
+        register("metro") {
+            this.dimension = dimension
+        }
+    }
 }
 
 dependencies {

--- a/sample-library/build.gradle.kts
+++ b/sample-library/build.gradle.kts
@@ -26,14 +26,14 @@ android {
         jvmTarget = "11"
     }
 
-    val dimension = "di_dimension"
-    flavorDimensions += dimension
+    val dimensionName = "di_dimension"
+    flavorDimensions += dimensionName
     productFlavors {
         register("hilt") {
-            this.dimension = dimension
+            dimension = dimensionName
         }
         register("metro") {
-            this.dimension = dimension
+            dimension = dimensionName
         }
     }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -31,6 +31,10 @@ android {
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             signingConfig = signingConfigs.getByName("debug")
+            matchingFallbacks += "hilt"
+        }
+        getByName("debug") {
+            matchingFallbacks += "hilt"
         }
     }
 
@@ -45,6 +49,17 @@ android {
     }
     kotlinOptions {
         jvmTarget = "11"
+    }
+
+    val dimension = "di_dimension"
+    flavorDimensions += dimension
+    productFlavors {
+        register("hilt") {
+            this.dimension = dimension
+        }
+        register("metro") {
+            this.dimension = dimension
+        }
     }
 }
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -31,10 +31,6 @@ android {
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             signingConfig = signingConfigs.getByName("debug")
-            matchingFallbacks += "hilt"
-        }
-        getByName("debug") {
-            matchingFallbacks += "hilt"
         }
     }
 
@@ -51,14 +47,14 @@ android {
         jvmTarget = "11"
     }
 
-    val dimension = "di_dimension"
-    flavorDimensions += dimension
+    val dimensionName = "di_dimension"
+    flavorDimensions += dimensionName
     productFlavors {
         register("hilt") {
-            this.dimension = dimension
+            dimension = dimensionName
         }
         register("metro") {
-            this.dimension = dimension
+            dimension = dimensionName
         }
     }
 }

--- a/sample/src/main/java/com/deliveryhero/whetstone/sample/MainActivity.kt
+++ b/sample/src/main/java/com/deliveryhero/whetstone/sample/MainActivity.kt
@@ -65,7 +65,6 @@ fun MainScreen(
     }
 }
 
-
 class BasicActivity : ComponentActivity() {
 
     private val viewModel by injectedViewModel<MainViewModel>()

--- a/sample/src/main/java/com/deliveryhero/whetstone/sample/MainService.kt
+++ b/sample/src/main/java/com/deliveryhero/whetstone/sample/MainService.kt
@@ -23,7 +23,6 @@ class MainService : Service() {
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-
         val notification = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
             .setContentTitle("${this.javaClass.simpleName} is running")
             .setContentText(dependency.getMessage("Service"))

--- a/sample/src/test/java/com/deliveryhero/whetstone/ExampleUnitTest.kt
+++ b/sample/src/test/java/com/deliveryhero/whetstone/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package com.deliveryhero.whetstone
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/whetstone-gradle-plugin/src/main/kotlin/com/deliveryhero/whetstone/gradle/WhetstonePlugin.kt
+++ b/whetstone-gradle-plugin/src/main/kotlin/com/deliveryhero/whetstone/gradle/WhetstonePlugin.kt
@@ -1,6 +1,6 @@
 package com.deliveryhero.whetstone.gradle
 
-import com.android.build.api.dsl.LibraryExtension
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.api.AndroidBasePlugin
@@ -16,7 +16,6 @@ import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.hasPlugin
 import org.gradle.kotlin.dsl.register
@@ -56,31 +55,38 @@ public class WhetstonePlugin : Plugin<Project> {
             target.addDependencies(extension)
         }
 
-        target.extensions.findByType<LibraryExtension>()?.apply {
-            buildTypes.configureEach {
-                val variantName = name.capitalized()
-                val sourceTaskName = "compile${variantName}Kotlin"
-                val generatedPath = "anvil/${name}/generated/META-INF/proguard"
+        addLocateWhetstoneProguardTask(target)
+    }
 
-                val locateWhetstoneProguardTask = target
-                    .tasks
-                    .register<ProguardLocatorTask>("locateWhetstone${variantName}Proguard") {
-                        // This task depends on the task that actually creates the file
-                        dependsOn(sourceTaskName)
+    private fun addLocateWhetstoneProguardTask(target: Project) {
+        val components = target.extensions.findByType(LibraryAndroidComponentsExtension::class.java)
+            ?: return
 
-                        locatedFiles.set(target.layout.buildDirectory.dir(generatedPath))
-                    }
+        // onVariants will be called for each variant (e.g., debug, release, freeDebug, etc.)
+        components.onVariants { variant ->
+            val variantName = variant.name.capitalized()
+            val sourceTaskName = "compile${variantName}Kotlin"
+            val generatedPath = "anvil/${variant.name}/generated/META-INF/proguard"
 
-                val generatedProguardFiles = locateWhetstoneProguardTask
-                    .flatMap { it.locatedFiles }
-                    .map { dir ->
-                        dir.asFileTree.filter { file -> file.name.endsWith(".pro") }
-                    }
+            val locateWhetstoneProguardTask = target
+                .tasks
+                .register<ProguardLocatorTask>("locateWhetstone${variantName}Proguard") {
+                    // This task depends on the task that actually creates the file
+                    dependsOn(sourceTaskName)
 
-                target.tasks.withType<ExportConsumerProguardFilesTask>().configureEach {
-                    if (name.contains(variantName, true)) {
-                        consumerProguardFiles.from(generatedProguardFiles)
-                    }
+                    locatedFiles.set(target.layout.buildDirectory.dir(generatedPath))
+                }
+
+
+            val generatedProguardFiles = locateWhetstoneProguardTask
+                .flatMap { it.locatedFiles }
+                .map { dir ->
+                    dir.asFileTree.filter { file -> file.name.endsWith(".pro") }
+                }
+
+            target.tasks.withType<ExportConsumerProguardFilesTask>().configureEach {
+                if (name.contains(variantName, true)) {
+                    consumerProguardFiles.from(generatedProguardFiles)
                 }
             }
         }


### PR DESCRIPTION
The Whetstone Gradle plugin has been updated to use the modern Android Gradle Plugin (AGP) Variant API for configuring consumer Proguard files in library modules.

The implementation was migrated from the older `LibraryExtension` and `buildTypes.configureEach` to `LibraryAndroidComponentsExtension` and the `onVariants` callback. This ensures that generated Proguard files are correctly added to all build variants, including combinations of build types and product flavors. The previous approach only supported build types.

To validate this change, the `sample-library` has been updated to include product flavors.