### PR TITLE
Fix release workflow + restore main to 1.1.7-SNAPSHOT

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # delivery-hero-tech bot PAT — actions/checkout persists this as the
+          # git credential for the rest of the job, so the post-release SNAPSHOT
+          # bump step can push to the protected `main` branch (the bot is on
+          # the branch-protection bypass list; the default GITHUB_TOKEN is not).
+          token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0
 
       - name: Set JDK version
@@ -96,13 +100,15 @@ jobs:
           sed -i.bak "s/^VERSION_NAME=.*/VERSION_NAME=$NEXT_VERSION/" gradle.properties
           rm gradle.properties.bak
 
-          # Configure git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Author the commit as the delivery-hero-tech bot (whose PAT is the
+          # persisted git credential from actions/checkout, and which is on the
+          # `main` branch-protection bypass list).
+          git config user.name "Delivery-Hero-Tech"
+          git config user.email "pd-mobile-bot@deliveryhero.com"
 
           # Checkout main branch (release events check out tags, leaving us in detached HEAD)
           git checkout main
-          git pull origin main
+          git pull --ff-only origin main
 
           # Commit and push
           git add gradle.properties

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,6 +44,21 @@ When you create a GitHub release:
 3. **Publishing**: Publishes artifacts to Maven Central with automatic promotion
 4. **Next Version**: Automatically commits `X.Y.(Z+1)-SNAPSHOT` to main branch
 
+## Required repo configuration
+
+The post-release SNAPSHOT bump pushes a commit directly to the protected `main` branch.
+That push is performed by the `delivery-hero-tech` org bot and depends on:
+
+- The `GH_TOKEN` repo secret (the bot's PAT) being available to
+  `.github/workflows/publish-release.yml` — wired via `actions/checkout`'s `token:`
+  input so the persisted git credentials carry the bot identity for the rest of the job.
+- `delivery-hero-tech` being included in the `main` branch-protection bypass list
+  ("Allow specified actors to bypass required pull requests"). Without this the push
+  is rejected with `GH006: Protected branch update failed`.
+
+If a fork ever needs to run this workflow, swap `GH_TOKEN` for an equivalent bot/PAT
+available there and add that identity to the fork's branch-protection bypass list.
+
 ## Version Scheme
 
 - **Release versions**: `1.2.3` (no SNAPSHOT suffix) - committed to main before creating GitHub release

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,8 +56,8 @@ That push is performed by the `delivery-hero-tech` org bot and depends on:
   ("Allow specified actors to bypass required pull requests"). Without this the push
   is rejected with `GH006: Protected branch update failed`.
 
-If a fork ever needs to run this workflow, swap `GH_TOKEN` for an equivalent bot/PAT
-available there and add that identity to the fork's branch-protection bypass list.
+If a fork needs to run this workflow, configure a `GH_TOKEN` secret with an
+equivalent bot/PAT and add that identity to the fork's branch-protection bypass list.
 
 ## Version Scheme
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ android.defaults.buildfeatures.resvalues=false
 com.squareup.anvil.trackSourceFiles=true
 # Library Information
 GROUP=com.deliveryhero.whetstone
-VERSION_NAME=1.1.6
+VERSION_NAME=1.1.7-SNAPSHOT
 # Maven central
 mavenCentralPublishing=true
 signAllPublications=true


### PR DESCRIPTION
## Summary

- Replace the post-release `git push origin main` (rejected by branch protection — see [run 22577295089](https://github.com/deliveryhero/whetstone/actions/runs/22577295089/job/65399740469)) with the same `git push`, but authenticated as the `delivery-hero-tech` org bot via `actions/checkout`'s `token:` input fed by a new `GH_TOKEN` repo secret.
- Bump `VERSION_NAME` from `1.1.6` to `1.1.7-SNAPSHOT` to restore the SNAPSHOT-on-main invariant the failed run never re-established. Without this, push-to-main publish runs no-op and the next release attempt would re-publish 1.1.6.
- Document the two prerequisites in `RELEASING.md`: the `GH_TOKEN` secret must exist and `delivery-hero-tech` must be in the `main` branch-protection bypass list.

## Required before the next release works

1. Add the **`GH_TOKEN`** repo secret containing the `delivery-hero-tech` bot PAT (you indicated you would add this).
2. Add **`delivery-hero-tech`** to the `main` branch-protection bypass list ("Allow specified actors to bypass required pull requests"). Today `restrictions.apps: []`, so this almost certainly needs to be added.

## Test plan

- [x] `./gradlew help -q` — Gradle configures with the new SNAPSHOT version.
- [x] `./gradlew build` — full unit test suite + apiCheck (run via the binary-validator plugin) pass locally.
- [x] `./gradlew detekt lint` — clean.
- [ ] CI `run-tests` and `Binary Compatibility Validation` checks pass on this PR.
- [ ] After merge + secret/bypass setup, the next release publishes to Maven Central **and** lands a `Prepare next development version 1.1.8-SNAPSHOT` commit on `main` authored by `Delivery-Hero-Tech`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)