### PR TITLE
docs: migrate oss.sonatype.org references to Maven Central Portal

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -81,6 +81,13 @@ jobs:
             echo "Github username: ${GITHUB_ACTOR}"
             cat gradle.properties >> whetstone-gradle-plugin/gradle.properties
             ./gradlew clean -x test -x lint publish :whetstone-gradle-plugin:publish -PmavenCentralAutomaticPublishing=true
+            echo "Submitted to Maven Central (sync may take up to 30 min)"
+            if [[ "${{ steps.version.outputs.is_release }}" == "true" ]]; then
+              echo "Verify release: https://repo1.maven.org/maven2/com/deliveryhero/whetstone/"
+              echo "Portal: https://central.sonatype.com/publishing/deployments"
+            else
+              echo "Verify snapshot metadata: https://central.sonatype.com/repository/maven-snapshots/com/deliveryhero/whetstone/whetstone/maven-metadata.xml"
+            fi
 
       - name: Bump to next SNAPSHOT version
         if: github.event_name == 'release' && steps.version.outputs.is_release == 'true'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.deliveryhero.whetstone/whetstone?label=stable)](https://central.sonatype.com/artifact/com.deliveryhero.whetstone/whetstone)
-[![Sonatype Snapshot](https://img.shields.io/nexus/s/com.deliveryhero.whetstone/whetstone?server=https%3A%2F%2Foss.sonatype.org&label=snapshot)](https://oss.sonatype.org/content/repositories/snapshots/com/deliveryhero/whetstone/)
+[![Snapshot](https://img.shields.io/maven-metadata/v?metadataUrl=https://central.sonatype.com/repository/maven-snapshots/com/deliveryhero/whetstone/whetstone/maven-metadata.xml&label=snapshot)](https://central.sonatype.com/repository/maven-snapshots/com/deliveryhero/whetstone/whetstone/)
 
 # Whetstone
 
@@ -61,7 +61,11 @@ To use snapshot builds, add the Sonatype snapshots repository to your project:
 repositories {
     mavenCentral()
     maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        name = "Central Portal Snapshots"
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        mavenContent {
+            snapshotsOnly()
+        }
     }
 }
 ```

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -114,7 +114,7 @@ Note: Using GitHub Releases is strongly recommended as it provides full automati
 
 **Maven Central not showing new version**
 - Automatic publishing is enabled, but Maven Central can take a few minutes to sync.
-- Check [Sonatype Nexus](https://central.sonatype.com/publishing/deployments) for deployment status.
+- Check the [Maven Central Publisher Portal](https://central.sonatype.com/publishing/deployments) for deployment status.
 
 **Next SNAPSHOT version not committed to `main`**
 - Most common cause: `GH_TOKEN` is missing or the bot is not on the branch-protection bypass list — see [Required repo configuration](#required-repo-configuration). The default `GITHUB_TOKEN` cannot push to a protected `main`, and the failure surfaces only at the bump step (after the artifact is already published to Maven Central).


### PR DESCRIPTION
## Summary

- Replaces broken `img.shields.io/nexus/s` snapshot badge with a working `maven-metadata` badge querying the Central Portal snapshot repo directly (verified live: resolves to `v1.1.8-SNAPSHOT`)
- Updates snapshot repository URL in README from `oss.sonatype.org/content/repositories/snapshots/` to `central.sonatype.com/repository/maven-snapshots/`
- Adds a post-publish log to the CI workflow with verification links (release: group root on repo1.maven.org + deployments portal; snapshot: maven-metadata.xml)
- Fixes "Sonatype Nexus" label in RELEASING.md troubleshooting to "Maven Central Publisher Portal" (URL was already correct)

The legacy `oss.sonatype.org` infrastructure was sunset in mid-2025.

## Test plan

- [ ] Confirm snapshot badge renders correctly on the README (should show current `-SNAPSHOT` version in orange)
- [ ] Confirm stable badge still renders (should show `v1.1.6`)
- [ ] After next snapshot CI run, verify the log prints the `maven-metadata.xml` verification URL
- [ ] After next release CI run, verify the log prints the `repo1.maven.org` and portal URLs

https://central.sonatype.com/repository/maven-snapshots/com/deliveryhero/whetstone/whetstone/1.1.8-SNAPSHOT/maven-metadata.xml